### PR TITLE
Adds Transitive.js to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Experimental and production transit hardware.
 - [Bikeshare Map](http://bikes.oobrien.com/) - Status of all worldwide bikeshare stations
 - [Bongo](http://ebongo.org) - Real-time Transit Tracking for Iowa City, Coralville and the University of Iowa. Awesome because it combines three disparate transit systems into one UI.
 - [Time & Wheel](http://timeandwheel.com/) - Travel country-wide in the USA with train, bus, plane or ferry.  Uses the open-source [tripover routing engine](https://github.com/joriswu/tripover).
+- [Transitive.js](https://github.com/conveyal/transitive.js) - Creates a customizable web map layer of transit routes using Leaflet or D3.
  
 ### Native Apps (open source)
 


### PR DESCRIPTION
A javascript library that allows users to add and style transit lines as a map layer over a base map. Can be used in D3 or Leaflet.  

See https://github.com/conveyal/transitive.js for some examples. 
