### PR TITLE
Remove Laidig fork of gtfs-validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,6 @@ Converters from various static schedule formats to GTFS.
 
 - [feedValidator](https://github.com/google/transitfeed/wiki/FeedValidator) - Google supported Python-based GTFS validator. 
 - [gtfs-validator](https://github.com/conveyal/gtfs-validator) - - A GTFS validator based on the Onebusaway GTFS Modules, runs in Java and is faster than the Google provided one. 
-- [gtfs-validator](https://github.com/laidig/gtfs-validator) - Fork of the Conveyal validator above, with additional checks. 
 - [GFTS Data Package Specification](https://github.com/Stephen-Gates/GTFS) - A [Data Package specification](http://specs.frictionlessdata.io/data-packages/) with validation accomplished with [Good Tables](http://goodtables.okfnlabs.org/). Includes a data package, schemas, tests, and uses South East Queensland GTFS data as an example.
 
 ### GTFS Realtime


### PR DESCRIPTION
Laidig's contributions are now merged upstream to the main conveyal/gtfs-validator project