### PR TITLE
GTFS to barefoot map.

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Converters from various static schedule formats to GTFS.
 - [Chouette](http://www.chouette.mobi/) - Converts French-Transmodel, SIRI, NETeX. See Chouette.mobi website for more info.
 - [osm2gtfs](https://github.com/grote/osm2gtfs) - Turn OpenStreetMap data and schedule information into GTFS.
 - [GTFS-OSM-Sync](https://github.com/CUTR-at-USF/gtfs-osm-sync) - A Java tool for synchronizing data in GTFS format with [OpenStreetMap.org](http://www.openstreetmap.org/).
+- [onebusaway-gtfs-to-barefoot] (https://github.com/OneBusAway/onebusaway-gtfs-to-barefoot) - A Java tool to create a barefoot mapfile from a GTFS file.
  
 #### GTFS Tools
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Converters from various static schedule formats to GTFS.
 - [Chouette](http://www.chouette.mobi/) - Converts French-Transmodel, SIRI, NETeX. See Chouette.mobi website for more info.
 - [osm2gtfs](https://github.com/grote/osm2gtfs) - Turn OpenStreetMap data and schedule information into GTFS.
 - [GTFS-OSM-Sync](https://github.com/CUTR-at-USF/gtfs-osm-sync) - A Java tool for synchronizing data in GTFS format with [OpenStreetMap.org](http://www.openstreetmap.org/).
-- [onebusaway-gtfs-to-barefoot] (https://github.com/OneBusAway/onebusaway-gtfs-to-barefoot) - A Java tool to create a barefoot mapfile from a GTFS file.
+- [onebusaway-gtfs-to-barefoot](https://github.com/OneBusAway/onebusaway-gtfs-to-barefoot) - A Java tool to create a barefoot mapfile from a GTFS file.
  
 #### GTFS Tools
 


### PR DESCRIPTION
Hi,

I have added a link to a tool I have recently created to create a barefoot map file from a GTFS file, which in turn can be used for map matching. The tool is published under the OneBusAway organisation.

Can this be considered for inclusion?

Thanks,

Sean.

