### PR TITLE
Add osmtogtfs python script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Converters from various static schedule formats to and from GTFS.
 - [osm2gtfs](https://github.com/grote/osm2gtfs) - Turn OpenStreetMap data and schedule information into GTFS.
 - [GTFS-OSM-Sync](https://github.com/CUTR-at-USF/gtfs-osm-sync) - A Java tool for synchronizing data in GTFS format with [OpenStreetMap.org](http://www.openstreetmap.org/).
 - [onebusaway-gtfs-to-barefoot](https://github.com/OneBusAway/onebusaway-gtfs-to-barefoot) - A Java tool to create a [Barefoot](https://github.com/bmwcarit/barefoot) mapfile from a GTFS file.
+- [osmtogtfs](https://github.com/hiposfer/osmtogtfs) - Python 3 script that exports GTFS feed from OpenStreetMap data.
  
 #### GTFS Tools
 


### PR DESCRIPTION
This PR adds [osmtogtfs](https://github.com/hiposfer/osmtogtfs) which is a tool to export partial GTFS feed from OpenStreetMap transit data.