### PR TITLE
Update Transit Techies NYC links

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Places to ask questions and find other community resources.
   - [OneBusAway Developers mailing list](http://groups.google.com/group/onebusaway-developers)
   - [OneBusAway API mailing list](http://groups.google.com/group/onebusaway-api)
   - [OneBusAway Slack chat](https://onebusaway.herokuapp.com/)
-- [Transit Techies NYC](https://www.meetup.com/Transit-Techies-NYC/) - NYC-based meetup for those interested in this repo. [Speaker list](https://github.com/tyleragreen/transit-techies-nyc) includes many contributors to this repo.
+- [Transit Techies NYC](https://transittechies.nyc/) - NYC-based meetup for those interested in this repo. [Speaker list](https://transittechies.nyc/past) includes many contributors to this repo.
 
 ### Data
 


### PR DESCRIPTION
Point Transit Techies NYC entry to the website and away from the deprecated repo.