### PR TITLE
Add CGTFS to libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Software that makes it easy to consume GTFS data in a variety of languages.
 - [Make GTFS](https://github.com/mrcagney/make_gtfs) - A Python library to make GTFS feeds from basic route information
 - [trread](https://github.com/r-gtfs/trread) - A transit (GTFS) file reader for R. 
 - [ESRI public-transit-tools](https://github.com/Esri/public-transit-tools) - Tools for working with public transit data in ArcGIS (license for ArcGIS required).
+- [CGTFS](https://github.com/rakhack/cgtfs) - C library for reading static GTFS feeds. Supports reading unpacked feeds into application memory or into SQLite databases.
 
 #### GTFS Converters
 


### PR DESCRIPTION
Adding a self-written library for reading GTFS static feeds. So far appears to be the first one explicitly targeting C language.