### PR TITLE
Added new GTFS-RT converter for Transloc API

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Converters from various static schedule formats to and from GTFS.
 - [Civic Transit](https://github.com/jestin/CivicTransit) - Screen-scrapes [KCATA’s](http://www.kcata.org/) TransitMaster WebWatch installation to produce a GTFS-realtime feed.
 - [GTFS-realtime VehiclePositions to GTFS-realtime TripUpdates (TransitClock)](http://thetransitclock.org) - Java application that can consume raw vehicle positions and generate prediction times in formats such as GTFS-realtime.  Formerly known as "Transitime".
 - [gtfs-realtime-translators](https://github.com/Intersection/gtfs-realtime-translators) - A Python-based tool to translate custom arrival API formats to GTFS-realtime.  As of July 2019 it supports LA Metro and SEPTA.
+- [Transloc API to GTFS-realtime](https://github.com/jonathonwpowell/transloc-to-gtfs-real-time) - A Node.js based tool to convert the Transloc API to GTFS-realtime.
 
 #### GTFS Realtime Utilities
 


### PR DESCRIPTION
I have been working on a Transloc API to GTFS-realtime converter, and I thought it might be helpful to add it to the list.  One problem is that the Transloc API has some important information missing such as trip_ids, but I still think this is useful to at least get realtime bus locations in GTFS-RT.