### PR TITLE
docs: Remove SQL to GTFS from GTFS category because it does not exist…

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,6 @@ Software that makes it easy to consume GTFS data in a variety of languages.
 - [GTFS to SQL](https://github.com/OpenMobilityData/GtfsToSql) - Parses a GTFS feed into an SQL database (used in [OpenMobilityData](https://openmobilitydata.org/)).
 - [OneBusAway GTFS Modules](https://github.com/OneBusAway/onebusaway-gtfs-modules/wiki) - A Java-based library for reading, writing, and transforming public transit data in the GTFS format, including database support.
 - [R5: Rapid Realistic Routing on Real-world and Reimagined networks](https://github.com/conveyal/r5) - A Java-based routing engine for multimodal (transit/bike/walk/car) networks. It currently plans many trips over a time window for analytics purposes, but may eventually support point-to-point journey planning.
-- [SQL to GTFS](https://github.com/OpenMobilityData/SqlToGtfs) - Convert an SQLite file generated with "GtfsToSql" back to a zipped GTFS file.
 
 #### JavaScript
 - [gtfs-sequelize](https://github.com/evansiroky/gtfs-sequelize) - Node.js library modeling the static GTFS using [sequelize.js](http://sequelizejs.com/).


### PR DESCRIPTION
Hi folks,
Please feel free to merge this PR. If my research serves me right, **SQL to GTFS** does not exist anymore. That is why I removed it from the GTFS category.

Cheers!