### PR TITLE
docs: Fix GTFS Realtime heading level

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Converters from various static schedule formats to and from GTFS.
 - [Transport Validator](https://github.com/etalab/transport-validator/) - An open-source validator implemented in [Rust](https://www.rust-lang.org/). Used by the [French National Access Point](https://transport.data.gouv.fr/validation/).
 
 
-#### GTFS Realtime
+### GTFS Realtime
 
 - [GTFS-realtime documentation](https://github.com/google/transit/tree/master/gtfs-realtime). Also available in [Español](https://github.com/google/transit/tree/master/gtfs-realtime/spec/es).
 - [GTFS-realtime Autodoc](https://laidig.github.io/gtfs-rt-autodoc/index.html) - Automatically generated documentation for GTFS-realtime, generated from the official [GTFS-realtime protocol buffer specification](https://github.com/google/transit/blob/master/gtfs-realtime/proto/gtfs-realtime.proto) and including some extensions.


### PR DESCRIPTION
Reformat GTFS Realtime heading level from "####" to "###" as implied by the TOC hierarchy. Useful for proper rendering on external platforms.