### PR TITLE
remove old listings of native apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,11 +198,9 @@ Apps people use when taking transit.
 
 #### Native Apps (closed source)
 
-- [ally](http://www.allyapp.com/)
 - [Transit](http://transitapp.com/)
 - [CityMapper](https://citymapper.com/)
 - [Moovit](http://moovitapp.com/)
-- [TransLoc Rider](http://translocrider.com/) - Real-time transit maps for over 100 transit systems.
 - [Transit Display](http://transitdisplay.com/) - Multimodal and real-time transit display software.
 - [Ualabee](https://ualabee.com/company/) - Community driven trip planner with focus on user interaction, users can report anomalies, upload pictures, edit transit data and chat with other passengers.
 


### PR DESCRIPTION
These domain names appear to have been taken over by advertisers and no longer have anything to do with transit