### PR TITLE
Add Spare GTFS-Flex builder to GTFS Data collection/maintenance tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,8 @@ Converters from various static schedule formats to and from GTFS.
 - [GTFS shape mapfit](https://github.com/HSLdevcom/gtfs_shape_mapfit) - Python tool that fits GTFS shape files and stops to a given OSM map file. Uses [pymapmatch](https://github.com/tru-hy/pymapmatch) for the matching.
 - [GTFS Builder](http://nationalrtap.org/Web-Apps/GTFS-Builder) - A free web-based application to help you create GTFS files. Maintained by the National Rural Transit Assistance Program (RTAP).
 - [gtfs-station-builder](https://github.com/kostjerry/gtfs-station-builder) - UI tool to help build the internal structure of stations (including pathways.txt)
-- [GTFS Text-to-Speech Tester](https://github.com/BlinkTagInc/node-gtfs-tts) - A command-line tool that reads GTFS stop names out loud using Text-to-Speech to determine which need Text-to-Speech values for tts_stop_name in stops.txt. 
+- [GTFS Text-to-Speech Tester](https://github.com/BlinkTagInc/node-gtfs-tts) - A command-line tool that reads GTFS stop names out loud using Text-to-Speech to determine which need Text-to-Speech values for tts_stop_name in stops.txt.
+- [Spare GTFS-Flex Builder](https://sparelabs.com/en/spare-gtfs-flex-builder) - A free tool that helps transit agencies easily create, manage, and export their transportation data in GTFS-Flex format. 
 
 #### GTFS Merge Tools
 - [combine_gtfs_feeds](https://github.com/psrc/combine_gtfs_feeds) - A Python tool to combine multiple gtfs feeds into one feed/dataset.


### PR DESCRIPTION
As GTFS-Flex has officially adopted recently and Spare Labs officially [shared their tool for GTFS-Flex](https://www.linkedin.com/posts/spare_gtfs-flex-builder-activity-7199479804486709248-sKuD?utm_source=share&utm_medium=member_desktop) (shared on [Slack](https://mobilitydata-io.slack.com/archives/CSP7HDF37/p1714403189427409) as well), adding the tool to the list.

cc: @LeoFrachet - Feel free to edit the description if needed, thanks!