### PR TITLE
Fix first heading of content table README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Have something to add or change? Open a [pull request](https://github.com/Mobili
 
 ### Table of Contents
 
-- [Getting started](#getting-started)
+- [Getting started](#gtfs-reference-resources)
 - [Community](#community)
 - [Data](#data)
 - [Software for Creating APIs](#software-for-creating-apis)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Have something to add or change? Open a [pull request](https://github.com/Mobili
 
 ### Table of Contents
 
-- [Getting started](#gtfs-reference-resources)
+- [GTFS Reference resources](#gtfs-reference-resources)
 - [Community](#community)
 - [Data](#data)
 - [Software for Creating APIs](#software-for-creating-apis)


### PR DESCRIPTION
The first link in the README.md was outdated and is hereby updated