### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Converters from various static schedule formats to and from GTFS.
 - [Amarillo](https://github.com/mfdz/amarillo) - Aggregates and enhances carpooling-offers and publishes them as GTFS(-RT)
 - [GTFS Studio](https://gtfs.studio) - Online editor for GTFS feeds
 - [Uttu](https://github.com/entur/uttu) - Back-end for Nplan, a simple timetable editor.
+- [GTFS Express](https://gtfsexpress.com) - Web application to edit, validate and analyze GTFS feeds — including Fares v2 and GTFS-Flex — with an interactive schedule grid and map editor, an SQL console with AI-assisted natural-language queries, and strict canonical validation via [MobilityData's gtfs-validator](https://github.com/MobilityData/gtfs-validator).
 
 #### GTFS Merge Tools
 - [combine_gtfs_feeds](https://github.com/psrc/combine_gtfs_feeds) - A Python tool to combine multiple gtfs feeds into one feed/dataset.
@@ -214,7 +215,6 @@ Converters from various static schedule formats to and from GTFS.
 - [GTFS-to-Chart](https://github.com/BlinkTagInc/gtfs-to-chart) - Creates stringline charts showing all vehicles on a transit route from GTFS data.
 - [GTFS Display](https://codeberg.org/dancingCycle/gtfs-display) - Analyse, monitor and maintain GTFS data ([Example instances](https://www.swingbe.de/activity/gtfs-display/)).
 - [PTNA](https://wiki.openstreetmap.org/wiki/Public_Transport_Network_Analysis) - Public Transit Nework Analysis is a open source system for finding and aggregating information about public transportation lines mapped in OSM.
-- [GTFS Explorer](https://gtfs-explorer.org) - Web application to upload, validate and visually explore GTFS feeds, featuring an interactive network map, route and stop inspection, schedule grids, and a network statistics dashboard.
 
 #### GTFS Timetable Publishing Tools
 


### PR DESCRIPTION
Follow-up to #345.

Since that PR was merged, the tool has been **renamed** from *GTFS Explorer* to **GTFS Express**, and its scope has grown well beyond analysis. It now also provides:

- an interactive schedule grid and map editor with full undo/redo, covering the GTFS Schedule core spec, Fares v1 and v2, and GTFS-Flex
- an SQL console for bulk edits, with AI-assisted natural-language queries
- strict canonical validation via the embedded MobilityData [`gtfs-validator`](https://github.com/MobilityData/gtfs-validator) JAR (v8.0.0).

## Changes in this PR

1. **Remove** the existing `GTFS Explorer` entry from `#### GTFS Analysis Tools`.
2. **Add** a new `GTFS Express` entry under `#### GTFS Data Collection and Maintenance Tools` - the same section as `GTFS Editor`, `GTFS Studio`, and `static-GTFS-manager` — which fits the editing-first positioning better.

## Proposed new entry (verbatim)

> - [GTFS Express](https://gtfsexpress.com) - Web application to edit, validate and analyze GTFS feeds — including Fares v2 and GTFS-Flex — with an interactive schedule grid and map editor, an SQL console with AI-assisted natural-language queries, and strict canonical validation via [MobilityData's gtfs-validator](https://github.com/MobilityData/gtfs-validator).

## Backward compatibility

The previous domain `gtfs-explorer.org` issues a 301 redirect to the new canonical domain `gtfsexpress.com`, so any external links to the old URL keep working.

---

Disclosure: I am the author of the tool.